### PR TITLE
Add explicit negative number encoding example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -241,6 +241,14 @@ Or as an escaped string:
 Valid numbers are in the range of the signed 64 bit integer.
 Larger numbers should use the Big Number type instead.
 
+A negative number, e.g. `-1234` is encoded with the normal prefix `-`:
+
+    :-1234<CR><LF>
+
+Or as an escaped string:
+
+    ":-1234\r\n"
+
 **Null**
 
 The null type is encoded just as `_\r\n`, which is just the underscore


### PR DESCRIPTION
Seems a little silly, but I noticed that `-inf` was the only actual negative number example, and as the number types are signed I've added an explicit example to show normal negative encodings like `-1234`. Noting this explicitly is perhaps also useful as the `-` is a special character elsewhere, being the type marker for a simple error.