### PR TITLE
fix: Blob String section literal

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -188,11 +188,11 @@ in the previous version of RESP.
 The string `"hello world"` is represented by the following protocol:
 
     $11<CR><LF>
-    helloworld<CR><LF>
+    hello world<CR><LF>
 
 Or as an escaped string:
 
-    "$11\r\nhelloworld\r\n"
+    "$11\r\nhello world\r\n"
 
 The length field is limited to the range of an unsigned 64 bit
 integer. Zero is a valid length, so the empty string is represented by:


### PR DESCRIPTION
In the Blob String section the literal "hello world" appeared, incorrectly, as "helloworld" throwing off length fields by 1.